### PR TITLE
Add site.url to load correctly bootstrap.min.js

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,7 @@
                 </p>
             </div>
             <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
-            <script src="/assets/js/bootstrap.min.js"></script>
+            <script src="{{ site.url }}/assets/js/bootstrap.min.js"></script>
             
             {% if site.code_highlight %}
             <script src="http://yandex.st/highlightjs/8.0/highlight.min.js"></script>


### PR DESCRIPTION
When spress site's are in subfolder, bootstrap.min.js script does not load correctly...
